### PR TITLE
feat(format): introduce shared format-common.sh and refactor format s…

### DIFF
--- a/scripts/format-common.sh
+++ b/scripts/format-common.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+# Shared utility library for format scripts
+set -euo pipefail
+
+# =============================================================================
+# COLOR OUTPUT FUNCTIONS
+# =============================================================================
+echoerr() { echo -e "\033[31m$*\033[0m" >&2; }
+echosuccess() { echo -e "\033[32m$*\033[0m"; }
+echowarn() { echo -e "\033[33m$*\033[0m"; }
+echoinfo() { echo -e "\033[34m$*\033[0m"; }
+
+# =============================================================================
+# GLOBAL VARIABLES (managed by common functions)
+# =============================================================================
+VERBOSE=false
+QUIET=false
+DRY_RUN=false
+HELP_REQUESTED=false
+FINAL_EXIT_CODE=0
+
+# =============================================================================
+# COMMON ARGUMENT PARSING
+# =============================================================================
+parse_common_args() {
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            -h|--help) HELP_REQUESTED=true; shift ;;
+            -v|--verbose) VERBOSE=true; shift ;;
+            -q|--quiet) QUIET=true; exec 1>/dev/null; shift ;;
+            --dry-run) DRY_RUN=true; shift ;;
+            *) break ;;
+        esac
+    done
+}
+
+# =============================================================================
+# HOOK INPUT PROCESSING
+# =============================================================================
+process_hook_input() {
+    local tool_name="$1"
+    local file_extensions="$2"  # Comma-separated: ".go,.proto"
+    local process_func="$3"
+    shift 3
+    local extra_args=("$@")
+
+    # Read from stdin (hook mode) or process arguments (direct mode)
+    if [[ $# -gt 0 ]]; then
+        # Direct command usage
+        for filepath in "$@"; do
+            process_single_file "$tool_name" "$filepath" "$file_extensions" "$process_func"
+        done
+    else
+        # Hook mode - read JSON from stdin
+        local input
+        input=$(cat)
+
+        if [[ -z "$input" ]]; then
+            echoerr "No input provided. Please provide a JSON input."
+            exit 2
+        fi
+
+        echoinfo "Input received: $input"
+
+        # Build jq filter for multiple extensions
+        local jq_filter=".tool_input.file_path"
+        local extension_filters=()
+        IFS=',' read -ra EXTENSIONS <<< "$file_extensions"
+        for ext in "${EXTENSIONS[@]}"; do
+            extension_filters+=("endswith(\"$ext\")")
+        done
+
+        # Join filters with " or "
+        local filter_string
+        filter_string=$(IFS=' or '; echo "${extension_filters[*]}")
+        jq_filter+=" | select($filter_string)"
+
+        local files
+        files=$(echo "$input" | jq -r "$jq_filter" 2>/dev/null || echo "")
+
+
+        if [[ -z "$files" ]]; then
+            local ext_list="${file_extensions//,/ }"
+            echoinfo "No $ext_list files found in the input."
+            exit 0
+        fi
+
+        for filepath in $files; do
+            process_single_file "$tool_name" "$filepath" "$file_extensions" "$process_func"
+        done
+    fi
+}
+
+# =============================================================================
+# INDIVIDUAL FILE PROCESSING
+# =============================================================================
+process_single_file() {
+    local tool_name="$1"
+    local filepath="$2"
+    local file_extensions="$3"
+    local process_func="$4"
+
+    # Check file extension
+    local matches_extension=false
+    IFS=',' read -ra EXTENSIONS <<< "$file_extensions"
+    for ext in "${EXTENSIONS[@]}"; do
+        if [[ "$filepath" == *"$ext" ]]; then
+            matches_extension=true
+            break
+        fi
+    done
+
+    if [[ "$matches_extension" == "false" ]]; then
+        return 0
+    fi
+
+    # Check if file exists
+    if [[ ! -f "$filepath" ]]; then
+        echoerr "File not found: $filepath"
+        FINAL_EXIT_CODE=2
+        return 2
+    fi
+
+    # Verbose logging
+    if [[ "$VERBOSE" == "true" ]]; then
+        echoinfo "Processing $filepath with $tool_name"
+    fi
+
+    # Execute tool-specific processing
+    "$process_func" "$filepath"
+    local exit_code=$?
+
+    if [[ $exit_code -ne 0 ]]; then
+        FINAL_EXIT_CODE=$exit_code
+    fi
+}
+
+# =============================================================================
+# TOOL EXECUTION WRAPPERS
+# =============================================================================
+run_tool() {
+    local tool_name="$1"
+    local check_cmd="$2"
+    local run_cmd="$3"
+    shift 3
+    local args=("$@")
+
+    # Check if tool is installed
+    if ! command -v "$check_cmd" &> /dev/null; then
+        echoerr "$tool_name is not installed. Please install it first."
+        return 2
+    fi
+
+    # Handle dry-run mode
+    if [[ "$DRY_RUN" == "true" ]]; then
+        echoinfo "[DRY-RUN] Would run: $run_cmd ${args[*]}"
+        return 0
+    fi
+
+    # Execute tool
+    if [[ "$VERBOSE" == "true" ]]; then
+        echoinfo "Running $tool_name on ${args[*]}"
+    fi
+    if ! eval "$run_cmd ${args[*]}"; then
+        echoerr "$tool_name failed on: ${args[*]}"
+        return 2
+    fi
+
+    if [[ "$VERBOSE" == "true" ]]; then
+        echosuccess "$tool_name completed successfully on: ${args[*]}"
+    fi
+    return 0
+}
+
+# =============================================================================
+# UTILITIES FOR SPECIFIC TOOLS
+# =============================================================================
+check_openapi_file() {
+    local filepath="$1"
+    grep -q "openapi:" "$filepath" || grep -q "swagger:" "$filepath"
+}
+
+filter_output_by_file() {
+    local output="$1"
+    local filepath="$2"
+    local filepath_without_pwd
+    filepath_without_pwd=$(echo "$filepath" | sed "s|$(pwd)/||")
+    echo "$output" | grep "$filepath_without_pwd" || true
+}
+
+# =============================================================================
+# FINALIZATION
+# =============================================================================
+finalize_format_script() {
+    local tool_name="$1"
+
+    if [[ $FINAL_EXIT_CODE -eq 0 ]]; then
+        echosuccess "All files passed $tool_name."
+    else
+        echoerr "$tool_name detected issues that need to be fixed."
+    fi
+
+    exit $FINAL_EXIT_CODE
+}
+
+# =============================================================================
+# INITIALIZATION
+# =============================================================================
+init_format_script() {
+    # Source security functions if available
+    local script_dir
+    script_dir="$(cd "$(dirname "${BASH_SOURCE[1]}")" && pwd)"
+    if [[ -f "$script_dir/../lib/security.sh" ]]; then
+        source "$script_dir/../lib/security.sh"
+    fi
+}
+
+# Initialize when sourced
+init_format_script

--- a/scripts/protoformat.sh
+++ b/scripts/protoformat.sh
@@ -1,15 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-echoerr() {
-    echo -e "\033[31m$*\033[0m" >&2
-}
-
-# Source security functions
+# Source common utilities
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-if [[ -f "$SCRIPT_DIR/../lib/security.sh" ]]; then
-    source "$SCRIPT_DIR/../lib/security.sh"
-fi
+source "$SCRIPT_DIR/format-common.sh"
 
 # Help function
 show_help() {
@@ -24,7 +18,7 @@ OPTIONS:
     -q, --quiet     Suppress non-error output
 
 DESCRIPTION:
-    Runs buf on .proto files for linting and formatting.
+    Runs buf fmt and buf lint on .proto files.
 
 EXAMPLES:
     # Lint all proto files
@@ -36,130 +30,34 @@ EXAMPLES:
 EOF
 }
 
-# Parse command line arguments
-while [[ $# -gt 0 ]]; do
-    case $1 in
-        -h|--help)
-            show_help
-            exit 0
-            ;;
-        -v|--verbose)
-            shift
-            ;;
-        -q|--quiet)
-            exec 1>/dev/null
-            shift
-            ;;
-        -*)
-            echoerr "Unknown option: $1"
-            show_help
-            exit 1
-            ;;
-        *)
-            break
-            ;;
-    esac
-done
+# Tool-specific processing
+process_proto_files() {
+    local filepath="$1"
 
-if ! command -v buf &> /dev/null; then
-    echoerr "buf is not installed. Please install it first: https://buf.build/docs/installation"
-    exit 2
-fi
+    # Format with buf
+    run_tool "buf fmt" "buf" "buf fmt -w" "$filepath" || return 2
 
-final_exit_code=0
-
-# Check if arguments are provided (direct command usage)
-if [[ $# -gt 0 ]]; then
-    # Process arguments directly
-    for filepath in "$@"; do
-        # Only process .proto files
-        if [[ "$filepath" != *.proto ]]; then
-            continue
+    # Lint with buf
+    local output
+    output=$(buf lint "$filepath" 2>&1 || true)
+    if [[ -n "$output" ]]; then
+        local file_specific
+        file_specific=$(filter_output_by_file "$output" "$filepath")
+        if [[ -n "$file_specific" ]]; then
+            echoerr "buf lint found issues: $file_specific"
+            return 2
         fi
-
-        echo "Formatting and checking file: $filepath"
-        if [[ ! -f "$filepath" ]]; then
-            echoerr "File not found: $filepath"
-            exit 2
-        fi
-
-        # Format with buf
-        echo "Running buf fmt on $filepath"
-        buf fmt -w "$filepath"
-        format_exit_code=$?
-
-        if [[ $format_exit_code -ne 0 ]]; then
-            echoerr "buf fmt failed on $filepath"
-            final_exit_code=2
-        else
-            echo "File formatted successfully with buf fmt"
-        fi
-
-        # Lint with buf
-        echo "Running buf lint on $filepath"
-        buf_output=$(buf lint "$filepath" 2>&1)
-        lint_exit_code=$?
-
-        if [[ $lint_exit_code -ne 0 ]]; then
-            echoerr "buf lint found issues: $buf_output"
-            final_exit_code=2
-        else
-            echo "No buf lint issues found"
-        fi
-    done
-else
-    # Read from stdin and parse JSON (hook usage)
-    INPUT=$(cat )
-    if [[ -z "$INPUT" ]]; then
-        echoerr "No input provided. Please provide a JSON input."
-        exit 2
     fi
-    echo "Input received: $INPUT"
-    files_changed=$(echo "$INPUT" | jq -r '.tool_input.file_path | select(endswith(".proto"))')
-    if [[ -z "$files_changed" ]]; then
-        echo "No .proto files found in the input."
-        exit 0
-    fi
-    for filepath in $files_changed; do
 
-        echo "Formatting and checking file: $filepath"
-        if [[ ! -f "$filepath" ]]; then
-            echoerr "File not found: $filepath"
-            exit 2
-        fi
+    return 0
+}
 
-        # Format with buf
-        echo "Running buf fmt on $filepath"
-        buf fmt -w "$filepath"
-        format_exit_code=$?
+# Main execution
+parse_common_args "$@"
+[[ "$HELP_REQUESTED" == "true" ]] && { show_help; exit 0; }
 
-        if [[ $format_exit_code -ne 0 ]]; then
-            echoerr "buf fmt failed on $filepath"
-            final_exit_code=2
-        else
-            echo "File formatted successfully with buf fmt"
-        fi
+# Process files
+process_hook_input "buf" ".proto" "process_proto_files" "$@"
 
-        # Lint with buf
-        echo "Running buf lint on $filepath"
-        buf_output=$(buf lint "$filepath" 2>&1)
-        lint_exit_code=$?
-        filepath_without_pwd=$(echo "$filepath" | sed "s|$(pwd)/||")
-        if [[ $lint_exit_code -ne 0 ]]; then
-            filespecific=$(echo "$buf_output" | grep "$filepath_without_pwd" || true)
-        fi
-
-        if [[ -n $filespecific ]]; then
-            echoerr "buf lint found issues in $filepath: $filespecific"
-            final_exit_code=2
-        else
-            echo "No buf lint issues found"
-        fi
-    done
-fi
-
-if [[ $final_exit_code -eq 0 ]]; then
-    echo "All files passed formatting and linting."
-fi
-
-exit $final_exit_code
+# Finalize
+finalize_format_script "proto formatting and linting"

--- a/scripts/shellformat.sh
+++ b/scripts/shellformat.sh
@@ -1,15 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-echoerr() {
-    echo -e "\033[31m$*\033[0m" >&2
-}
-
-# Source security functions
+# Source common utilities
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-if [[ -f "$SCRIPT_DIR/../lib/security.sh" ]]; then
-    source "$SCRIPT_DIR/../lib/security.sh"
-fi
+source "$SCRIPT_DIR/format-common.sh"
 
 # Help function
 show_help() {
@@ -36,97 +30,18 @@ EXAMPLES:
 EOF
 }
 
-# Parse command line arguments
-while [[ $# -gt 0 ]]; do
-    case $1 in
-        -h|--help)
-            show_help
-            exit 0
-            ;;
-        -v|--verbose)
-            shift
-            ;;
-        -q|--quiet)
-            exec 1>/dev/null
-            shift
-            ;;
-        -*)
-            echoerr "Unknown option: $1"
-            show_help
-            exit 1
-            ;;
-        *)
-            break
-            ;;
-    esac
-done
+# Tool-specific processing
+process_shell_files() {
+    local filepath="$1"
+    run_tool "shellcheck" "shellcheck" "shellcheck --format=tty --severity=warning" "$filepath"
+}
 
-if ! command -v shellcheck &> /dev/null; then
-    echoerr "shellcheck is not installed. Please install it first."
-    exit 2
-fi
+# Main execution
+parse_common_args "$@"
+[[ "$HELP_REQUESTED" == "true" ]] && { show_help; exit 0; }
 
-final_exit_code=0
+# Process files
+process_hook_input "shellcheck" ".sh" "process_shell_files" "$@"
 
-# Check if arguments are provided (direct command usage)
-if [[ $# -gt 0 ]]; then
-    # Process arguments directly
-    for filepath in "$@"; do
-        # Only process .sh files
-        if [[ "$filepath" != *.sh ]]; then
-            continue
-        fi
-        
-        echo "Checking file: $filepath"
-        if [[ ! -f "$filepath" ]]; then
-            echoerr "File not found: $filepath"
-            exit 2
-        fi
-        
-        shellcheck_output=$(shellcheck "$filepath" --format=tty --severity=warning 2>&1)
-        exit_code=$?
-
-        if [[ $exit_code -ne 0 ]]; then
-            echoerr "Script has shellcheck errors, fix these one by one: $shellcheck_output" 
-            final_exit_code=2
-        else
-            echo "No shellcheck problems found"
-        fi
-    done
-else
-    # Read from stdin and parse JSON (hook usage)
-    INPUT=$(cat )
-    if [[ -z "$INPUT" ]]; then
-        echoerr "No input provided. Please provide a JSON input."
-        exit 2
-    fi
-    echo "Input received: $INPUT"
-    files_changed=$(echo "$INPUT" | jq -r '.tool_input.file_path | select(endswith(".sh"))')
-    if [[ -z "$files_changed" ]]; then
-        echo "No .sh files found in the input."
-        exit 0
-    fi
-    for filepath in $files_changed; do
-
-        echo "Checking file: $filepath"
-        if [[ ! -f "$filepath" ]]; then
-            echoerr "File not found: $filepath"
-            exit 2
-        fi
-        shellcheck_output=$(shellcheck "$filepath" --format=tty --severity=warning 2>&1)
-        exit_code=$?
-
-        if [[ $exit_code -ne 0 ]]; then
-            echoerr "Script has shellcheck errors, fix these one by one: $shellcheck_output" 
-            final_exit_code=2
-        else
-            echo "No shellcheck problems found"
-        fi
-    done
-fi
-
-if [[ $final_exit_code -eq 0 ]]; then
-    echo "All files passed shellcheck."
-fi
-
-exit $final_exit_code
+# Finalize
+finalize_format_script "shell script linting"

--- a/test-format-common.sh
+++ b/test-format-common.sh
@@ -1,0 +1,249 @@
+#!/usr/bin/env bash
+# Comprehensive test suite for format-common.sh
+
+set -euo pipefail
+
+# Source the library to test
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/scripts/format-common.sh"
+
+# Test setup
+TEST_DIR="/tmp/format-common-tests"
+mkdir -p "$TEST_DIR"
+cd "$TEST_DIR"
+
+# Test counters
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+# Helper functions
+print_test_result() {
+    local test_name="$1"
+    local result="$2"
+    local details="${3:-}"
+
+    TESTS_RUN=$((TESTS_RUN + 1))
+
+    if [[ "$result" == "PASS" ]]; then
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo "✅ PASS: $test_name"
+    else
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        echo "❌ FAIL: $test_name"
+        if [[ -n "$details" ]]; then
+            echo "   Details: $details"
+        fi
+    fi
+}
+
+# Test functions
+test_argument_parsing() {
+    echo "Testing argument parsing..."
+
+    # Test -h flag
+    HELP_REQUESTED=false
+    VERBOSE=false
+    QUIET=false
+    DRY_RUN=false
+    parse_common_args -h
+    print_test_result "parse_common_args -h" "$([[ "$HELP_REQUESTED" == "true" ]] && echo PASS || echo FAIL)"
+
+    # Test -v flag
+    HELP_REQUESTED=false
+    VERBOSE=false
+    parse_common_args -v
+    print_test_result "parse_common_args -v" "$([[ "$VERBOSE" == "true" ]] && echo PASS || echo FAIL)"
+
+    # Test --dry-run flag
+    DRY_RUN=false
+    parse_common_args --dry-run
+    print_test_result "parse_common_args --dry-run" "$([[ "$DRY_RUN" == "true" ]] && echo PASS || echo FAIL)"
+
+    # Test multiple flags
+    HELP_REQUESTED=false
+    VERBOSE=false
+    DRY_RUN=false
+    parse_common_args -v --dry-run
+    if [[ "$VERBOSE" == "true" && "$DRY_RUN" == "true" ]]; then
+        print_test_result "parse_common_args multiple flags" "PASS"
+    else
+        print_test_result "parse_common_args multiple flags" "FAIL" "VERBOSE=$VERBOSE, DRY_RUN=$DRY_RUN"
+    fi
+}
+
+test_file_processing() {
+    echo "Testing file processing..."
+
+    # Create test files
+    echo "test" > test.go
+    echo "test" > test.py
+    echo "test" > test.sh
+    echo "test" > test.proto
+    echo "openapi: 3.0.0" > openapi.yaml
+
+    # Test process_single_file with matching extension
+    FINAL_EXIT_CODE=0
+    process_single_file "test-tool" "test.go" ".go,.py" "true"  # Dummy processing function
+    print_test_result "process_single_file matching .go" "PASS"
+
+    # Test process_single_file with non-matching extension
+    process_single_file "test-tool" "test.sh" ".go,.py" "false"  # Should skip
+    print_test_result "process_single_file non-matching .sh" "PASS"
+
+    # Test process_file not found
+    FINAL_EXIT_CODE=0
+    process_single_file "test-tool" "nonexistent.go" ".go" "false" 2>/dev/null || true
+    print_test_result "process_single_file file not found" "$([[ "$FINAL_EXIT_CODE" -eq 2 ]] && echo PASS || echo FAIL)"
+
+    # Cleanup
+    rm -f test.go test.py test.sh test.proto openapi.yaml
+}
+
+test_openapi_detection() {
+    echo "Testing OpenAPI detection..."
+
+    # Create OpenAPI file
+    echo "openapi: 3.0.0" > test-openapi.yaml
+    # Create non-OpenAPI file
+    echo "not openapi" > test-regular.yaml
+
+    # Test OpenAPI file detection
+    if check_openapi_file test-openapi.yaml; then
+        print_test_result "check_openapi_file OpenAPI file" "PASS"
+    else
+        print_test_result "check_openapi_file OpenAPI file" "FAIL"
+    fi
+
+    # Test non-OpenAPI file detection
+    if ! check_openapi_file test-regular.yaml; then
+        print_test_result "check_openapi_file non-OpenAPI file" "PASS"
+    else
+        print_test_result "check_openapi_file non-OpenAPI file" "FAIL"
+    fi
+
+    # Test Swagger detection
+    echo "swagger: 2.0" > test-swagger.yaml
+    if check_openapi_file test-swagger.yaml; then
+        print_test_result "check_openapi_file Swagger file" "PASS"
+    else
+        print_test_result "check_openapi_file Swagger file" "FAIL"
+    fi
+
+    # Cleanup
+    rm -f test-openapi.yaml test-regular.yaml test-swagger.yaml
+}
+
+test_hook_input_processing() {
+    echo "Testing hook input processing..."
+
+    # Create test file
+    echo "test" > test.sh
+
+    # Test hook input with matching file
+    test_input='{"tool_input":{"file_path":"test.sh"}}'
+    echo "$test_input" | FINAL_EXIT_CODE=0 process_hook_input "test-tool" ".sh" "true" && \
+    print_test_result "process_hook_input matching file" "PASS" || \
+    print_test_result "process_hook_input matching file" "FAIL"
+
+    # Test hook input with non-matching file - should exit 0 gracefully
+    test_input='{"tool_input":{"file_path":"test.py"}}'
+    echo "$test_input" | FINAL_EXIT_CODE=0 process_hook_input "test-tool" ".sh" "false" && \
+    print_test_result "process_hook_input non-matching file" "PASS" || \
+    print_test_result "process_hook_input non-matching file" "FAIL"
+
+    # Test multiple extensions
+    echo "test" > test.go
+    test_input='{"tool_input":{"file_path":"test.go"}}'
+    echo "$test_input" | FINAL_EXIT_CODE=0 process_hook_input "test-tool" ".go,.py,.sh" "true" && \
+    print_test_result "process_hook_input multiple extensions" "PASS" || \
+    print_test_result "process_hook_input multiple extensions" "FAIL"
+
+    # Cleanup
+    rm -f test.sh test.go test.py
+}
+
+test_output_filtering() {
+    echo "Testing output filtering..."
+
+    # Create test output and file
+    local test_output="error in $(pwd)/test.sh
+another error in different-file.txt
+error in $(pwd)/test.sh: line 5"
+
+    local filepath="$(pwd)/test.sh"
+
+    # Test filtering by file
+    local filtered
+    filtered=$(filter_output_by_file "$test_output" "$filepath")
+
+    if echo "$filtered" | grep -q "test.sh" && ! echo "$filtered" | grep -q "different-file.txt"; then
+        print_test_result "filter_output_by_file" "PASS"
+    else
+        print_test_result "filter_output_by_file" "FAIL" "Unexpected filtered output: $filtered"
+    fi
+}
+
+test_tool_execution() {
+    echo "Testing tool execution..."
+
+    # Test tool availability check
+    if run_tool "nonexistent-tool" "nonexistent-tool" "echo" 2>/dev/null; then
+        print_test_result "run_tool nonexistent tool" "FAIL"
+    else
+        print_test_result "run_tool nonexistent tool" "PASS"
+    fi
+
+    # Test dry-run mode
+    DRY_RUN=true
+    local output
+    output=$(run_tool "test-tool" "echo" "echo test" 2>&1 || true)
+    if echo "$output" | grep -q "DRY-RUN"; then
+        print_test_result "run_tool dry-run" "PASS"
+    else
+        print_test_result "run_tool dry-run" "FAIL" "Expected DRY-RUN output"
+    fi
+    DRY_RUN=false
+
+    # Test real tool execution
+    local exit_code
+    output=$(run_tool "echo" "echo" "echo test" 2>&1)
+    exit_code=$?
+    if [[ $exit_code -eq 0 ]]; then
+        print_test_result "run_tool successful execution" "PASS"
+    else
+        print_test_result "run_tool successful execution" "FAIL" "Exit code: $exit_code"
+    fi
+}
+
+# Run all tests
+echo "🧪 Running format-common.sh test suite..."
+echo "====================================="
+
+test_argument_parsing
+echo
+test_file_processing
+echo
+test_openapi_detection
+echo
+test_hook_input_processing
+echo
+test_output_filtering
+echo
+test_tool_execution
+echo
+
+# Print summary
+echo "====================================="
+echo "📊 Test Results:"
+echo "   Tests run: $TESTS_RUN"
+echo "   Passed: $TESTS_PASSED"
+echo "   Failed: $TESTS_FAILED"
+
+if [[ $TESTS_FAILED -eq 0 ]]; then
+    echo "✅ All tests passed!"
+    exit 0
+else
+    echo "❌ $TESTS_FAILED test(s) failed!"
+    exit 1
+fi

--- a/test.proto
+++ b/test.proto
@@ -1,0 +1,1 @@
+syntax = "proto3";


### PR DESCRIPTION
…cripts

- Add scripts/format-common.sh to centralize arg parsing, hook input processing, per-file processing, run_tool wrappers, output filtering and finalization.
- Refactor goformat.sh, openapi-lint.sh, protoformat.sh and shellformat.sh to source the common library and use its helpers.
- Add test-format-common.sh test suite and test.proto sample file.